### PR TITLE
Added a fuzzy search fallback

### DIFF
--- a/src/zeal_feeds/main.py
+++ b/src/zeal_feeds/main.py
@@ -52,12 +52,21 @@ def main():
 def search(args) -> str | None:
     """Search for matching docsets."""
     docset_data = _load_docset_index(args.url)
+    fallback = False
 
     search_text = args.text
+
     matches = sorted(docset_data.search(search_text))
     if not matches:
+        matches = sorted(docset_data.fallback_search(search_text))
+        fallback = True
+    if not matches:
         return "No matching docsets found"
-    print("Matching docsets:")
+
+    if fallback:
+        print("No exact matches, did you mean:")
+    else:
+        print("Matching docsets:")
     for docset in matches:
         print(docset)
     return None

--- a/tests/test_user_contrib.py
+++ b/tests/test_user_contrib.py
@@ -103,3 +103,17 @@ def test_docset_collection_get(item, expected):
 def test_docset_collection_search(search, expected):
     """Verify docset search functionality."""
     assert sorted(COLLECTION.search(search)) == sorted(expected)
+
+
+@pytest.mark.parametrize(
+    ("search", "expected"),
+    [
+        ("food", [DOCSETS["foo"]]),
+        ("foobra", [DOCSETS["foobar"]]),
+        ("acec", [DOCSETS["acme"]]),
+        ("amecs", []),
+    ],
+)
+def test_docset_collection_fuzzy_search(search, expected):
+    """Verify docset search functionality."""
+    assert sorted(COLLECTION.fallback_search(search)) == sorted(expected)


### PR DESCRIPTION
Hey! 

I was reading about approximate string matching and I though this would be an interesting application.

This basically adds a fallback feature to the `search` command. If no exact matches are found it will fallback to returning candidates with [edit distance](https://en.wikipedia.org/wiki/Levenshtein_distance) <= 2. 

For example, normal behavior is unchanged:
```
$ zeal-feeds search attrs
Using cached index of user contributed docsets
Matching docsets:
attrs (22.2.0)
```
but it will also give suggestions if no matches are found:
```
$ zeal-feeds search attsr
Using cached index of user contributed docsets
No exact matches, did you mean:
attrs (22.2.0)
```
but not too many:
```
 $ zeal-feeds search attsasdf
Using cached index of user contributed docsets
No matching docsets found
```