### PR TITLE
More configuration location options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,11 @@ Categories:
 ### Added
 
 * Recommend *uv* as another preferred method of installation/execution.
+* Add `--config` option to specify `Zeal.conf` configuration file.
+
+### Fixed
+
+* Failure to find configuration folder for Flatpak. [#9](https://github.com/smsearcy/zeal-feeds/issues/9)
 
 
 ## 0.2.3 - 2024-09-13

--- a/src/zeal_feeds/console.py
+++ b/src/zeal_feeds/console.py
@@ -1,0 +1,7 @@
+"""Helper for the Rich console."""
+
+from rich.console import Console
+
+__all__ = ("console",)
+
+console = Console()

--- a/src/zeal_feeds/zeal.py
+++ b/src/zeal_feeds/zeal.py
@@ -17,6 +17,7 @@ from cattrs import Converter
 from platformdirs import user_config_path
 
 from . import ApplicationError
+from .console import console
 from .user_contrib import DocSet
 
 FEED_URL = "https://zealusercontributions.vercel.app/api/docsets/{name}.xml"
@@ -40,12 +41,20 @@ class Zeal:
     docset_path: Path
 
     @classmethod
-    def from_config(cls):
-        """Get the path where Docsets are installed to."""
+    def load_config(cls, config_file: str):
+        """Load specified config file to locate Docsets."""
+        docset_path = _read_docset_path_from_config(Path(config_file))
+        return cls(docset_path)
+
+    @classmethod
+    def find_config(cls):
+        """Find configuration to point to where Docsets are installed to."""
         if sys.platform == "win32":
             docset_path = _windows_docset_install_path()
         else:
-            docset_path = _linux_docset_install_path()
+            config_file = _find_linux_config_file()
+            console.print("Using configuration", config_file)
+            docset_path = _read_docset_path_from_config(config_file)
         if not docset_path.exists():
             docset_path.mkdir(parents=True)
         return cls(docset_path)
@@ -68,6 +77,9 @@ class Zeal:
         # ensure docset folder given the correct name
         expected_folder_name = f"{docset.name}.docset"
         if docset_folder.name != expected_folder_name:
+            console.print(
+                f"Fixing folder name for {docset.name!r}:", expected_folder_name
+            )
             destination = self.docset_path / expected_folder_name
             if destination.exists():
                 raise ApplicationError(
@@ -88,15 +100,34 @@ class Zeal:
         json.dump(converter.unstructure(metadata), meta_json.open("w"), indent=2)
 
 
-def _linux_docset_install_path() -> Path:
+def _find_linux_config_file() -> Path:
     """Get the docset path from the Zeal configuration file."""
-    config_file = user_config_path("Zeal") / "Zeal.conf"
+    # Try typical XDG `~/.config` first, look for Flatpak as fallback
+    config_path = user_config_path("Zeal")
+    if not config_path.exists():
+        # Look for Flatpak configuration
+        # (but the Fedora Registry uses a different case than Flathub)
+        for flatpak_id in ("org.zealdocs.Zeal", "org.zealdocs.zeal"):
+            config_path = Path(f"~/.var/app/{flatpak_id}/config/Zeal").expanduser()
+            if config_path.exists():
+                break
+        else:
+            console.print("ERROR: Zeal configuration folder not found.", style="red")
+            console.print("Specify 'Zeal.conf' file with '--config'.", style="red")
+            raise ApplicationError()
+    return config_path / "Zeal.conf"
+
+
+def _read_docset_path_from_config(config_file: Path) -> Path:
     if not config_file.exists():
-        raise ApplicationError("Zeal configuration not found.")
+        console.print("ERROR: Zeal configuration file not found.", style="red")
+        console.print("Specify 'Zeal.conf' file with '--config'.", style="red")
+        raise ApplicationError()
     zeal_config = ConfigParser()
     zeal_config.read_file(config_file.open())
 
     docset_path = zeal_config.get("docsets", "path")
+    console.print("Installing docsets to", docset_path)
     return Path(docset_path)
 
 
@@ -104,7 +135,7 @@ def _windows_docset_install_path() -> Path:
     """Get the docset path from the Zeal registry entries."""
     # gatekeeper so that mypy doesn't choke on `winreg` in Linux
     if sys.platform != "win32":
-        raise RuntimeError("Incorrect platform for Windows registry")
+        raise ApplicationError("Incorrect platform for Windows registry")
 
     import winreg
 


### PR DESCRIPTION
Several fixes for finding configuration files:
* Search for Flatpak configuration folders when looking for `Zeal.conf`.
* Add `--config` option to `zeal-feeds install` to specify location of `Zeal.conf`

Print more output about files/paths being used for troubleshooting.

Add `--dry-run` option to `zeal-feeds install`.

Closes #9